### PR TITLE
Fix minor typos and CSS issues

### DIFF
--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -32,7 +32,7 @@ export default {
     > div {
       text-align: left;
       line-height: 1.8;
-      white-space: 1;
+      white-space: normal;
     }
     img {
       width: 100%;

--- a/src/views/Source.vue
+++ b/src/views/Source.vue
@@ -30,7 +30,7 @@
           </div>
           <div class="item">
             <label for="detune">detune : <span>{{detune}}</span> </label>
-            <input type="range" min="-2000" max="2000" step="1" vid="detuneRange" v-model="detune" @input="changeHandler">
+            <input type="range" min="-2000" max="2000" step="1" id="detuneRange" v-model="detune" @input="changeHandler">
           </div>
         </div>
         <div v-show="sourceType==='1'">

--- a/src/views/StereoPannerNode.vue
+++ b/src/views/StereoPannerNode.vue
@@ -21,7 +21,7 @@
         </div>
         <div class="item">
           <label for="detune">detune : <span>{{detune}}</span> </label>
-          <input type="range" min="-2000" max="2000" step="1" vid="detuneRange" v-model="detune" @input="changeHandler">
+          <input type="range" min="-2000" max="2000" step="1" id="detuneRange" v-model="detune" @input="changeHandler">
         </div>
       </div>
       <div class="audio-note">

--- a/src/views/Tone.vue
+++ b/src/views/Tone.vue
@@ -86,7 +86,7 @@ export default {
     > div {
       text-align: left;
       line-height: 1.8;
-      white-space: 1;
+      white-space: normal;
     }
     img {
       width: 100%;

--- a/src/views/WaveSurfer.vue
+++ b/src/views/WaveSurfer.vue
@@ -52,7 +52,7 @@ export default {
     > div {
       text-align: left;
       line-height: 1.8;
-      white-space: 1;
+      white-space: normal;
     }
     img {
       width: 100%;

--- a/src/views/WebAudioApi.vue
+++ b/src/views/WebAudioApi.vue
@@ -21,7 +21,7 @@
         </div>
         <div class="item">
           <label for="detune">detune : <span>{{detune}}</span> </label>
-          <input type="range" min="-2000" max="2000" step="1" vid="detuneRange" v-model="detune" @input="changeHandler">
+          <input type="range" min="-2000" max="2000" step="1" id="detuneRange" v-model="detune" @input="changeHandler">
         </div>
       </div>
       <div class="audio-note">

--- a/src/views/_template.vue
+++ b/src/views/_template.vue
@@ -2,7 +2,7 @@
   <div id="tone">
     <h1> Tone.js </h1>
     <div class="content">
-      <button @clicl="clickHandler"></button>
+      <button @click="clickHandler"></button>
     </div>
   </div>
 </template>
@@ -37,7 +37,7 @@ export default {
     > div {
       text-align: left;
       line-height: 1.8;
-      white-space: 1;
+      white-space: normal;
     }
     img {
       width: 100%;


### PR DESCRIPTION
## Summary
- fix a click event typo in template component
- correct invalid `white-space` CSS values
- fix incorrect attribute names for detune controls

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9f56a008330b99918e45bf07218